### PR TITLE
Update pom.xml

### DIFF
--- a/afterburner-java/pom.xml
+++ b/afterburner-java/pom.xml
@@ -91,12 +91,6 @@
             <version>1.7.0</version>
         </dependency>
         <dependency>
-            <!-- explicitly added to avoid security issues with 1.30, remove when part of parent -->
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.32</version>
-        </dependency>
-        <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>


### PR DESCRIPTION
Remove snake.yaml dependency.

Snake.yaml is included in spring boot 2.7.x.

Snake.yaml version 1.x have at least 1 vulnerability. Snake.yaml v2 has solved this, but this new version will not be included in spring boot 2.7.x. It will be in 3.2.x.

Nevertheless, spring-boot itself is not vulnerable in reading yaml files during boot using the safe constructor. We don't read yaml files ourselves, so we are not vulnerable and should ignore the vulnerability in snyk instead.